### PR TITLE
Check entry path length to allow non-standard CRA entry file

### DIFF
--- a/lib/supportMultipleEntry.js
+++ b/lib/supportMultipleEntry.js
@@ -25,8 +25,9 @@ function _default(entries) {
     var defaultEntryHTMLPlugin = config.plugins.filter(function (plugin) {
       return plugin.constructor.name === 'HtmlWebpackPlugin';
     })[0];
-    defaultEntryHTMLPlugin.options.chunks = [defaultEntryName];
-    var necessaryEntry = config.entry.filter(function (file) {
+    defaultEntryHTMLPlugin.options.chunks = [defaultEntryName]; // If there is only one entry file then it should not be necessary for the rest of the entries
+
+    var necessaryEntry = config.entry.length === 1 ? [] : config.entry.filter(function (file) {
       return !appIndexes.includes(file);
     });
     var multipleEntry = {};

--- a/src/supportMultipleEntry.ts
+++ b/src/supportMultipleEntry.ts
@@ -18,7 +18,8 @@ export default function(entries:EntryWebpack[] | null) {
       return plugin.constructor.name === 'HtmlWebpackPlugin';
     })[0];
     defaultEntryHTMLPlugin.options.chunks = [defaultEntryName];
-    const necessaryEntry = config.entry.filter(function(file:string) {
+    // If there is only one entry file then it should not be necessary for the rest of the entries
+    const necessaryEntry = config.entry.length === 1 ? [] : config.entry.filter(function(file:string) {
       return !appIndexes.includes(file);
     });
     const multipleEntry:EntryMap = {};


### PR DESCRIPTION
If there is only one entry file then it should not be necessary for the rest of the entries

This was an issue for me as you exclude /src/index.{ext} from the config.entries but I had already amended the main entry point path.
This meant the main entry point was being bundled with the additional entries and defeats the purpose of having multiple entries.
This PR is backward compatible as it will only remove the "default" entry points if there are more than one files (which shouldn't be happening on CRA anyway) and it removed the /src/index.{ext} file so necessaryEntry was always becoming an empty array.